### PR TITLE
hashes are new Case insensitive

### DIFF
--- a/src/main/java/it/w0rd/filters/RoutingFilter.java
+++ b/src/main/java/it/w0rd/filters/RoutingFilter.java
@@ -39,7 +39,7 @@ public class RoutingFilter implements Filter {
             Logger.getLogger("RedirectFilter").info("Request is file or api call " + requestURI);
             chain.doFilter(request, response);
         } else {
-            String hash = requestURI.substring(1);
+            String hash = requestURI.substring(1).toLowerCase();
             Logger.getLogger("RedirectFilter").info("Resolving hash " + hash);
             try {
                 ShortenedUrl shortenedUrl = shortenerService.expand(hash);

--- a/src/test/java/it/w0rd/filters/RoutingFilterTest.java
+++ b/src/test/java/it/w0rd/filters/RoutingFilterTest.java
@@ -83,4 +83,19 @@ public class RoutingFilterTest {
         assertThat(response.getStatus(),equalTo(HttpServletResponse.SC_MOVED_PERMANENTLY));
     }
 
+    @Test
+    public void shouldRedirectHashCaseInsensitive() throws Throwable {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/wAvE");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        Mockito.when(shortenerService.expand("wave")).thenReturn(new ShortenedUrl(new URI("http://www.test.com"), "wave", "Description"));
+
+        routingFilter.doFilter(request, response, filterChain);
+
+        Mockito.verify(filterChain, times(0))
+                .doFilter(Mockito.any(HttpServletRequest.class), Mockito.any(HttpServletResponse.class));
+
+        assertThat(response.getStatus(),equalTo(HttpServletResponse.SC_MOVED_PERMANENTLY));
+    }
+
 }

--- a/src/test/java/it/w0rd/filters/RoutingFilterTest.java
+++ b/src/test/java/it/w0rd/filters/RoutingFilterTest.java
@@ -88,14 +88,10 @@ public class RoutingFilterTest {
         MockHttpServletRequest request = new MockHttpServletRequest("GET", "/wAvE");
         MockHttpServletResponse response = new MockHttpServletResponse();
 
-        Mockito.when(shortenerService.expand("wave")).thenReturn(new ShortenedUrl(new URI("http://www.test.com"), "wave", "Description"));
-
         routingFilter.doFilter(request, response, filterChain);
 
-        Mockito.verify(filterChain, times(0))
-                .doFilter(Mockito.any(HttpServletRequest.class), Mockito.any(HttpServletResponse.class));
-
-        assertThat(response.getStatus(),equalTo(HttpServletResponse.SC_MOVED_PERMANENTLY));
+        Mockito.verify(shortenerService, times(1))
+                .expand("wave");
     }
 
 }


### PR DESCRIPTION
When an a hash is received , the filter converts that hash to lowercase, so the users of w0rd.it doesn't need to remember the capitalisation of words or can enter/share the word with Capital first character if they decide is more nice for them